### PR TITLE
Added default bind for fullscreen toggling where it is expectable

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -156,6 +156,7 @@ void CBinds::SetDefaults()
 	Bind(KEY_F6, "toggle_lua_console");
 	Bind(KEY_F7, "+hotbar");
 
+	Bind(KEY_F11, "toggle gfx_fullscreen 0 1");
 	Bind(KEY_F12, "+unlock_mouse");
 
 	// DDRace


### PR DESCRIPTION
In many programs full screen is toggled by the F11 key, therefore people try this often and can be contented by this default bind.