### PR TITLE
Fix lua userdata compiler warning

### DIFF
--- a/src/engine/external/luabridge/detail/Userdata.h
+++ b/src/engine/external/luabridge/detail/Userdata.h
@@ -335,7 +335,7 @@ template <class T>
 class UserdataValue : public Userdata
 {
 private:
-  UserdataValue <T> (UserdataValue <T> const&);
+  UserdataValue(UserdataValue<T> const&);
   UserdataValue <T> operator= (UserdataValue <T> const&);
 
   char m_storage [sizeof (T)];


### PR DESCRIPTION
Fixes the following compiler warning on a modern C++ compiler. It gets triggerd for almost all translation units and is extremly spammy.

```
src/engine/external/luabridge/detail/Userdata.h:338:22: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  338 |   UserdataValue <T> (UserdataValue <T> const&);
      |                      ^~~~~~~~~~~~~~~~~
src/engine/external/luabridge/detail/Userdata.h:338:22: note: remove the ‘< >’
```

I am aware this is a third party library and it should not be patched line by line. But I wanted to avoid bigger changes by upgrading the entire library.

I did only update that one affected line of code to match their current recent version: https://github.com/vinniefalco/LuaBridge/blob/ade28532d998ada20048db7f5a649acaf66a4532/Source/LuaBridge/detail/Userdata.h#L272