### PR TITLE
Update to new ddnet domain ddnet.org

### DIFF
--- a/data/edtc/mapdbs.cfg
+++ b/data/edtc/mapdbs.cfg
@@ -1,3 +1,3 @@
-http://maps.ddnet.tw
+http://maps.ddnet.org
 https://github.com/AllTheHaxx/maps-db/blob/master
 http://heinrich5991.de/teeworlds/maps/maps

--- a/data/edtc/skindbs.cfg
+++ b/data/edtc/skindbs.cfg
@@ -5,5 +5,5 @@
 # variable `cl_skin_db_file' to the path of your own file.
 #
 
-https://ddnet.tw/skins/skin/
+https://ddnet.org/skins/skin/
 https://raw.githubusercontent.com/AllTheHaxx/skin-db/master/

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -456,7 +456,7 @@ void CClient::LoadMapDatabaseUrls()
 	{
 		MapDbUrl e;
 		e.prior = 0;
-		e.url = std::string("http://maps.ddnet.tw");
+		e.url = std::string("http://maps.ddnet.org");
 		m_MapDbUrls.add(e);
 	}
 }

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -10,7 +10,7 @@
 
 #define SERVERLIST_CACHE_FILE "tmp/cache/serverlist.bin"
 #define DDNET_INFO_FILE "tmp/cache/ddnet-info.json"
-#define DDNET_INFO_URL "https://info.ddnet.tw/info"
+#define DDNET_INFO_URL "https://info.ddnet.org/info"
 
 /*
 	Structure: CServerInfo

--- a/src/game/client/components/skindownload.cpp
+++ b/src/game/client/components/skindownload.cpp
@@ -334,7 +334,7 @@ void CSkinDownload::LoadUrls()
 
 	if(NumURLs() == 0)
 	{
-		m_aSkinDbUrls.add(std::string("https://ddnet.tw/skins/skin/"));
+		m_aSkinDbUrls.add(std::string("https://ddnet.org/skins/skin/"));
 	}
 }
 


### PR DESCRIPTION
ddnet switched from ddnet.tw to ddnet.org a while ago. And the ddnet.tw domain will become increasingly unreliable.

Fixed the following error

```
[26-08-12 13:38:20][fetcher/error]: task failed. ('https://info.ddnet.tw/info' -> 'tmp/cache/ddnet-info.json') libcurl error: Operation too slow. Less than 500 bytes/sec transferred the last 5 seconds
[26-08-12 13:38:20][srvbrowse/error]: failed to parse ddnet info of length 0 (no server can be shown)
```